### PR TITLE
Mantém a proporção da imagem da homepage em mobile devices

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,11 +12,18 @@ export default function Index({data}) {
         css={css`
           display: flex;
           justify-content: center;
+          width: 100%;
         `}
       >
         <img
           src="https://secure.meetupstatic.com/photos/event/1/2/2/1/600_481324641.jpeg"
           alt="react cwb logo"
+          css={css`
+            width: 100%;
+            @media (max-width: 768px) {
+              height: 100%;
+            }
+          `}
         />
       </section>
       <section>


### PR DESCRIPTION
No último ReactCWB, fui acessar o site da comunidade (que achei bacana ser em Gatsby) e sendo dono de um iPhone SE, você está acostumado a ver coisas como:

![IMG_0136](https://user-images.githubusercontent.com/7315217/73611294-45c79800-45bf-11ea-97c2-dfbfbd885d0c.PNG)

Resolvi tentar arrumar aqui, usando css da forma como o projeto está usando e testando via ngrok no meu próprio celular (porque emular o SO, browser e user agent não causa esse erro em desktops). Deu boa! 😄

Resultado:

![IMG_0137](https://user-images.githubusercontent.com/7315217/73611317-9b03a980-45bf-11ea-98e4-0c0a2b32fa5a.PNG)

#TamoJunto 🤜🤛

P.S.: Também tem o `object-fit: contain` para `img` que faz exatamente o que queria, mas o container dele continua desproporcional, daí o resultado faz parecer que tem um padding vertical na imagem.